### PR TITLE
Add 100ms delay to allow for config to complete and reset flag to clear

### DIFF
--- a/examples/SPI/Example_01_SPI_RotationVector/Example_01_SPI_RotationVector.ino
+++ b/examples/SPI/Example_01_SPI_RotationVector/Example_01_SPI_RotationVector.ino
@@ -90,6 +90,8 @@ void setReports(void) {
   } else {
     Serial.println("Could not enable rotation vector");
   }
+  delay(100); // This delay allows enough time for the BNO086 to accept the new 
+              // configuration and clear its reset status
 }
 
 void loop() {

--- a/examples/SPI/Example_02_SPI_ResetCheck/Example_02_SPI_ResetCheck.ino
+++ b/examples/SPI/Example_02_SPI_ResetCheck/Example_02_SPI_ResetCheck.ino
@@ -80,14 +80,9 @@ void setup() {
   }
   Serial.println("BNO08x found!");
 
-  if( myIMU.requestResetReason() == true ) {
-      Serial.print(F("Reset Reason: "));
-      printResetReasonName(myIMU.getResetReason());
-      Serial.println();
-    }
-  else {
-    Serial.println("Reset Reason Request failed.");
-  }
+  Serial.print(F("Reset Reason: "));
+  printResetReasonName(myIMU.getResetReason());
+  Serial.println();
 
   setReports();
 
@@ -104,6 +99,8 @@ void setReports(void) {
   } else {
     Serial.println("Could not enable gyro");
   }
+  delay(100); // This delay allows enough time for the BNO086 to accept the new 
+              // configuration and clear its reset status
 }
 
 void loop() {
@@ -115,14 +112,9 @@ void loop() {
   // different resets.
   if (myIMU.wasReset()) {
     Serial.println(" ------------------ BNO08x has reset. ------------------ ");
-    if( myIMU.requestResetReason() == true ) {
-        Serial.print(F("Reset Reason: "));
-        printResetReasonName(myIMU.getResetReason());
-        Serial.println();
-      }
-    else {
-      Serial.println("Reset Reason Request failed.");
-    }
+    Serial.print(F("Reset Reason: "));
+    printResetReasonName(myIMU.getResetReason());
+    Serial.println();
 
     setReports();  // We'll need to re-enable reports after any reset.
   }

--- a/examples/SPI/Example_03_SPI_Sleep/Example_03_SPI_Sleep.ino
+++ b/examples/SPI/Example_03_SPI_Sleep/Example_03_SPI_Sleep.ino
@@ -91,6 +91,8 @@ void setReports(void) {
   } else {
     Serial.println("Could not enable rotation vector");
   }
+  delay(100); // This delay allows enough time for the BNO086 to accept the new 
+              // configuration and clear its reset status  
 }
 
 void loop() {


### PR DESCRIPTION
-Adding this 100ms delay into setReports allows enough time for the configuration to process and the sensor to clear its reset status flag. When the main loop comes around again and checks for a reset, it no longer sees the previous reset flag and then can continue on to reading the sensor.