### PR TITLE
added setReorientation function

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,13 @@ In addition the BNO08x IMU provides a built-in step counter, tap detector, activ
 
 This Arduino Library was built off the [original library](https://github.com/sparkfun/SparkFun_BNO080_Arduino_Library) written by Nathan Seidle ([SparkFun](http://www.sparkfun.com)).
 
-Thanks to all those who have helped improve the original library:
+Thanks to all those who have helped improve this library!
 
+This BNO086 Library - CEVA-DSP Sh2 Driver-based improvements:
+* LazaroFilm for adding setReorientation() [PR15](https://github.com/sparkfun/SparkFun_BNO08x_Arduino_Library/pull/15)
+* rah2501 for fixing an INT/RST pin bug [PR13](https://github.com/sparkfun/SparkFun_BNO08x_Arduino_Library/pull/13)
+
+Original BNO080 Library improvements:
 * blendmaster for adding [Linear Accel report](https://github.com/sparkfun/SparkFun_BNO080_Arduino_Library/pull/4)
 * per1234 for fixing our [keywords file](https://github.com/sparkfun/SparkFun_BNO080_Arduino_Library/pull/12)
 * fm4dd for typo - [PR 19](https://github.com/sparkfun/SparkFun_BNO080_Arduino_Library/pull/19)

--- a/src/SparkFun_BNO08x_Arduino_Library.cpp
+++ b/src/SparkFun_BNO08x_Arduino_Library.cpp
@@ -995,6 +995,18 @@ bool BNO08x::clearTare()
   return true;
 }
 
+bool BNO08x::setReorientation(sh2_Quaternion_t *orientation)
+{
+  int status = sh2_setReorientation(orientation);
+
+  if (status != SH2_OK)
+  {
+    return false;
+  }
+
+  return true;
+}
+
 // //This tells the BNO08x to begin calibrating
 // //See page 50 of reference manual and the 1000-4044 calibration doc
 // void BNO08x::sendCalibrateCommand(uint8_t thingToCalibrate)

--- a/src/SparkFun_BNO08x_Arduino_Library.cpp
+++ b/src/SparkFun_BNO08x_Arduino_Library.cpp
@@ -995,6 +995,13 @@ bool BNO08x::clearTare()
   return true;
 }
 
+// setReorientation()
+// Contributed by githhub user LazaroFilm (Victor Lazaro) Nov 2023.
+// https://github.com/sparkfun/SparkFun_BNO08x_Arduino_Library/pull/15
+// This function takes a quaternion and applies it to the rotation vector output as an offset.
+// This can be used in conjunction to the tare functions to offset the output manually.
+// To reset, simply send a zeroed out quaternion to the function.
+
 bool BNO08x::setReorientation(sh2_Quaternion_t *orientation)
 {
   int status = sh2_setReorientation(orientation);

--- a/src/SparkFun_BNO08x_Arduino_Library.h
+++ b/src/SparkFun_BNO08x_Arduino_Library.h
@@ -257,6 +257,8 @@ public:
 	bool tareNow(bool zAxis=false, sh2_TareBasis_t basis=SH2_TARE_BASIS_ROTATION_VECTOR);
 	bool saveTare();
 	bool clearTare();
+
+	bool setReorientation(sh2_Quaternion_t *orientation);
 	
 	uint8_t getTapDetector();
 	uint64_t getTimeStamp();


### PR DESCRIPTION
Added a setReorientation function that takes a quaternion and applies it to the rotation vector output as an offset.

This can be used in conjunction to the tare functions to offset the output manually. 
To reset, simply send a zeroed out quaternion to the function.

Details on [SH2 documentation 6.4.3.3 Set Reorientation (0x02)](https://www.ceva-dsp.com/wp-content/uploads/2019/10/SH-2-Reference-Manual.pdf)