### PR TITLE
Example 20 Bitwise OR Fix

### DIFF
--- a/examples/Example_20_CalibrationSettings/Example_20_CalibrationSettings.ino
+++ b/examples/Example_20_CalibrationSettings/Example_20_CalibrationSettings.ino
@@ -118,7 +118,7 @@ void setup() {
 
   // Enable dynamic calibration for desired sensors (accel, gyro, and mag)
   // uncomment/comment out as needed to try various options
-  if (myIMU.setCalibrationConfig(SH2_CAL_ACCEL || SH2_CAL_GYRO || SH2_CAL_MAG) == true) { // all three sensors
+  if (myIMU.setCalibrationConfig(SH2_CAL_ACCEL | SH2_CAL_GYRO | SH2_CAL_MAG) == true) { // all three sensors
   //if (myIMU.setCalibrationConfig(SH2_CAL_ACCEL || SH2_CAL_MAG) == true) { // Default settings
   //if (myIMU.setCalibrationConfig(SH2_CAL_ACCEL) == true) { // only accel
     Serial.println(F("Calibration Command Sent Successfully"));


### PR DESCRIPTION
This commit fixes a bug in the Example 20 - Calibration Settings where logical OR was used instead of bitwise OR.  The result is that the IMU's `setCalibrationConfig()` was evaluated with value 1 rather than 7.